### PR TITLE
v0.4.0

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,6 +23,13 @@ jobs:
           profile: minimal
           toolchain: ${{ matrix.rust }}
           override: true
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - uses: actions-rs/cargo@v1
         with:
           command: build
@@ -30,6 +37,16 @@ jobs:
         with:
           command: test
           args: --lib
+      - name: Generate Coverage
+        if: matrix.os == 'ubuntu-latest' && matrix.rust == 'stable'
+        run: |
+          cargo install cargo-tarpaulin
+          cargo tarpaulin --verbose --all-features --workspace --timeout 120 --out Xml
+      - name: Upload Coverage
+        uses: codecov/codecov-action@v1
+        if: matrix.os == 'ubuntu-latest' && matrix.rust == 'stable'
+        with:
+          fail_ci_if_error: true
 
   # Lint:
   #   runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [v0.4.0] - 2020-06-26
 ### Changed
  - `Shell::filter_names` now return `Iterator` instead of `Vec`.
  - `Shell::new_with_streams` is removed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed
  - `Shell::filter_names` now return `Iterator` instead of `Vec`.
+ - `Shell::new_with_streams` is removed.
+ - `cheats::io` is not private.
 
 ## [v0.3.1] - 2020-06-19
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Changed
+ - `Shell::filter_names` now return `Iterator` instead of `Vec`.
+
 ## [v0.3.1] - 2020-06-19
 ### Added
  - Added logging to functions and methods

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cheats"
 description = "A game shell backend."
-version = "0.3.1"
+version = "0.4.0"
 homepage = "https://erayerdin.hashnode.dev"
 repository = "https://github.com/erayerdin/cheats"
 license = "Apache-2.0"
@@ -17,4 +17,4 @@ logos = "0.11.4"
 log = "0.4.8"
 
 [dev-dependencies]
-rstest = "0.6.3"
+rstest = "0.6.4"

--- a/README.md
+++ b/README.md
@@ -4,18 +4,24 @@
 [![License][license_badge]](LICENSE.txt)
 [![Total Downloads][total_downloads_badge]][crate_url]
 [![Recent Downloads][recent_downloads_badge]][crate_url]
-[![Build on Master][master_build_badge]][actions_url]
-[![Build on Development][development_build_badge]][actions_url]
+
+| | Build | Coverage
+|-|-|-|
+| **master** | [![Build on Master][master_build_badge]][actions_url] | [![Coverage on Master][master_coverage_badge]][codecov_url] |
+| **development** | [![Build on Development][development_build_badge]][actions_url] | [![Coverage on Development][development_coverage_badge]][codecov_url] |
 
 [version_badge]: https://img.shields.io/crates/v/cheats?label=version&style=flat-square&logo=rust
 [license_badge]: https://img.shields.io/crates/l/cheats?label=license&style=flat-square
 [total_downloads_badge]: https://img.shields.io/crates/d/cheats?label=downloads%20%28total%29&style=flat-square
 [recent_downloads_badge]: https://img.shields.io/crates/dr/cheats?label=downloads%20%28recent%29&style=flat-square
-[master_build_badge]: https://img.shields.io/github/workflow/status/erayerdin/cheats/CI/master?label=build%20%28master%29&logo=github&style=flat-square
-[development_build_badge]: https://img.shields.io/github/workflow/status/erayerdin/cheats/CI/development?label=build%20%28development%29&logo=github&style=flat-square
+[master_build_badge]: https://img.shields.io/github/workflow/status/erayerdin/cheats/CI/master?logo=github&style=flat-square
+[development_build_badge]: https://img.shields.io/github/workflow/status/erayerdin/cheats/CI/development?logo=github&style=flat-square
+[master_coverage_badge]: https://img.shields.io/codecov/c/gh/erayerdin/cheats/master?style=flat-square
+[development_coverage_badge]: https://img.shields.io/codecov/c/gh/erayerdin/cheats/development?style=flat-square
 
 [crate_url]: https://crates.io/crates/cheats
 [actions_url]: https://github.com/erayerdin/cheats/actions
+[codecov_url]: https://codecov.io/gh/erayerdin/cheats
 
 cheats is a shell backend for games. Basically, it helps you 
 invoke functionality with a Valve-game-like shell grammar.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -211,7 +211,7 @@ use std::collections::HashSet;
 use std::io::{Read, Write};
 
 pub mod code;
-pub mod io;
+mod io;
 mod parser;
 
 #[derive(Debug, Snafu)]
@@ -252,25 +252,25 @@ impl<'a> Shell<'a> {
         }
     }
 
-    /// Initializes a Shell with custom stream.
-    /// By stream, it is meant a struct that implements both [Read][read_trait]
-    /// and [Write][write_trait] trait.
-    ///
-    /// [read_trait]: https://doc.rust-lang.org/std/io/trait.Read.html
-    /// [write_trait]: https://doc.rust-lang.org/std/io/trait.Write.html
-    pub fn new_with_streams(
-        stdout: Option<Box<dyn ReadWrite>>,
-        stderr: Option<Box<dyn ReadWrite>>,
-    ) -> Self {
-        debug!("Initializing Shell with custom streams...");
-        trace!("is stdout none: {}", stdout.is_none());
-        trace!("is stderr none: {}", stderr.is_none());
-        Self {
-            codes: HashSet::new(),
-            stdout: stdout.unwrap_or(Box::new(Stream::new())),
-            stderr: stderr.unwrap_or(Box::new(Stream::new())),
-        }
-    }
+    // /// Initializes a Shell with custom stream.
+    // /// By stream, it is meant a struct that implements both [Read][read_trait]
+    // /// and [Write][write_trait] trait.
+    // ///
+    // /// [read_trait]: https://doc.rust-lang.org/std/io/trait.Read.html
+    // /// [write_trait]: https://doc.rust-lang.org/std/io/trait.Write.html
+    // pub fn new_with_streams(
+    //     stdout: Option<Box<dyn ReadWrite>>,
+    //     stderr: Option<Box<dyn ReadWrite>>,
+    // ) -> Self {
+    //     debug!("Initializing Shell with custom streams...");
+    //     trace!("is stdout none: {}", stdout.is_none());
+    //     trace!("is stderr none: {}", stderr.is_none());
+    //     Self {
+    //         codes: HashSet::new(),
+    //         stdout: stdout.unwrap_or(Box::new(Stream::new())),
+    //         stderr: stderr.unwrap_or(Box::new(Stream::new())),
+    //     }
+    // }
 
     /// Registers a code to Shell. Returns [CodeAlreadyExists](enum.ShellError.html) if
     /// the code with provided name already exists in the shell.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,17 +123,28 @@
 //!
 //!  - `query`: A query to filter code names.
 //!  - `starts_with`: If `true`, filters code names using `starts_with`, else uses `contains`.
-//!  - `sort`: If `true`, sorts code names alphabetically.
 //!
 //! ```rust
 //! // assuming you have `cl_hello`, `sv_foo`, `sv_foobar`
 //!
-//! let sv_codes = shell.filter_names("sv", true, true);
+//! let sv_codes: Vec<&str> = shell.filter_names("sv", true).collect();
 //! assert_eq!(sv_codes, ["sv_foo", "sv_foobar"]);
 //!
-//! let foo_codes = shell.filter_names("foo", false, true);
+//! let foo_codes: Vec<&str> = shell.filter_names("foo", false).collect();
 //! assert_eq!(foo_codes, ["sv_foo", "sv_foobar"]),
 //! ```
+//!
+//! While, in this case, the `Vec` of code names are ordered, it might not be in larger
+//! examples. In this case, you can sort a `Vec` by using `sort` on it.
+//!
+//! ```rust
+//! let sv_codes: Vec<&str> = shell.filter_names("sv", true).collect();
+//! sv_codes.sort();
+//! ```
+//!
+//! Note that `filter_names` method actually returns an
+//! [Iterator](https://doc.rust-lang.org/std/iter/trait.Iterator.html), which, then,
+//! you can `collect` into a `Vec<&str>`.
 //!
 //! ## Running Script
 //!
@@ -306,40 +317,36 @@ impl<'a> Shell<'a> {
     ///  - `query`: The query to filter code names against.
     ///  - `starts_with`: Use `starts_with`. If `false`, it uses `contains`.
     ///  - `sort`: Sort code names alphabetically.
-    pub fn filter_names(&self, query: &str, starts_with: bool, sort: bool) -> Vec<&str> {
+    pub fn filter_names(
+        &'a self,
+        query: &'a str,
+        starts_with: bool,
+    ) -> Box<dyn Iterator<Item = &'a str> + 'a> {
         debug!("Filtering code names...");
         trace!("query: {}", query);
         trace!("starts with: {}", starts_with);
-        trace!("sort: {}", sort);
 
-        debug!("Filtering codes...");
-        let mut codenames: Vec<&str> = self
-            .codes
-            .iter()
-            .filter(|c| match starts_with {
-                true => {
-                    let do_filter = c.name.starts_with(query);
-                    trace!("`{}` starts with `{}`: {}", c.name, query, do_filter);
-                    do_filter
-                }
-                false => {
-                    let do_filter = c.name.contains(query);
-                    trace!("`{}` contains `{}`: {}", c.name, query, do_filter);
-                    do_filter
-                }
-            })
-            .map(|c| {
-                debug!("Mapping `{}` to &str...", c.name);
-                c.name
-            })
-            .collect();
-
-        if sort {
-            debug!("Sorting code names...");
-            codenames.sort();
-        }
-
-        codenames
+        debug!("Generating code iterator...");
+        Box::new(
+            self.codes
+                .iter()
+                .filter(move |c| match starts_with {
+                    true => {
+                        let do_filter = c.name.starts_with(query);
+                        trace!("`{}` starts with `{}`: {}", c.name, query, do_filter);
+                        do_filter
+                    }
+                    false => {
+                        let do_filter = c.name.contains(query);
+                        trace!("`{}` contains `{}`: {}", c.name, query, do_filter);
+                        do_filter
+                    }
+                })
+                .map(|c| {
+                    debug!("Mapping `{}` to &str...", c.name);
+                    c.name
+                }),
+        )
     }
 
     /// Invokes commands with given input. You can read from a file.
@@ -558,10 +565,16 @@ mod tests {
             .register("sv_foobar", Box::new(SvFoobar))
             .expect("Could not register sv_foobar.");
 
-        let sv_foo_names = shell.filter_names("sv_foo", true, true);
-        assert_eq!(sv_foo_names, ["sv_foo", "sv_foobar"]);
+        let sv_foo_names: HashSet<&str> = shell.filter_names("sv_foo", true).collect();
+        assert_eq!(
+            sv_foo_names,
+            HashSet::from_iter(["sv_foo", "sv_foobar"].iter().cloned())
+        );
 
-        let foo_names = shell.filter_names("foo", false, true);
-        assert_eq!(foo_names, ["sv_foo", "sv_foobar"]);
+        let foo_names: HashSet<&str> = shell.filter_names("foo", false).collect();
+        assert_eq!(
+            foo_names,
+            HashSet::from_iter(["sv_foo", "sv_foobar"].iter().cloned())
+        );
     }
 }


### PR DESCRIPTION
### Changed
 - `Shell::filter_names` now return `Iterator` instead of `Vec`.
 - `Shell::new_with_streams` is removed.
 - `cheats::io` is not private.